### PR TITLE
jspm configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "main": "js/foundation/foundation",
+  "shim": {
+    "js/foundation/foundation.*": "./foundation",
+    "js/foundation/foundation": ["jquery", "../vendor/custom.modernizr"]
+  },
+  "ignore": [
+    "js/foundation.min.js", 
+    "scss", 
+    "js/vendor/jquery.cookie.js", 
+    "js/vendor/jquery.js",
+    "js/vendor/fastclick.js",
+    "js/vendor/jquery.autocomplete.js",
+    "js/vendor/placeholder.js"
+  ],
+  "buildConfig": {
+    "uglify": true
+  }
+}


### PR DESCRIPTION
I've just been configuring this repo for jspm, and have managed to get it working nicely.

_Edit 11/30: I've remove the simpler entry points feature for the sake of configuration simplicity over ease of use._

The configuration provided in the pull request, allows usage like the following:

http://jsbin.com/ugEfizA/3/edit

Basically, one can load with `jspm.import('foundation/js/foundation/foundation.magellan')` etc, all dependency managed.

The key points here are:
1. Shimming global dependencies. All plugins are made dependent on foundation core to ensure load order, just like the RequireJS shim.
2. Uglification with source maps

Then when served off the CDN like in the example, all the dependencies are served with SPDY. Alternatively download the full repo with `jspm install foundation`.

It would be great to have this supported in the package, instead of needing an override for all this stuff.

Any questions at all just let me know.
